### PR TITLE
Add grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,26 @@ updates:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
+  groups:
+    rubocop:
+      patterns:
+        - "rubocop*"
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
+  groups:
+    babel:
+      patterns:
+        - "@babel/*"
+    fontawesome:
+      patterns:
+        - "@fortawesome/*"
+    rails:
+      patterns:
+        - "@rails/*"
+    webpack:
+      patterns:
+        - "webpack*"


### PR DESCRIPTION
By default, Dependabot raises a single pull request for each dependency that needs to be updated to a newer version. You can use groups to create sets of dependencies (per package manager), so that Dependabot opens a single pull request to update multiple dependencies at the same time.

Close #612

Ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups