### PR TITLE
Use GitHub deprecated formatter for stylelint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -110,4 +110,4 @@ jobs:
       run: pnpm install
     - name: Run Stylelint
       if: steps.changed-files.outputs.any_changed == 'true'
-      run: pnpm stylelint app/**/*.{scss,css}
+      run: pnpm stylelint app/**/*.{scss,css} --formatter=github


### PR DESCRIPTION
This formatter has been deprecated, but the suggested alternative does
not work and seems unmaintained

Ref:
- https://github.com/xt0rted/stylelint-actions-formatters/issues/187
- https://github.com/xt0rted/stylelint-problem-matcher/issues/461
- https://github.com/xt0rted/stylelint-problem-matcher/issues/592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow for improved Stylelint output compatibility with GitHub.
	- Corrected YAML formatting for the Stylelint step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->