### PR TITLE
Do not send telemetry stats to Selenium

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 Capybara.register_driver :custom_chrome do |app|
+  # Opt-out for Selenium data collection.
+  #
+  # Note: This is the only available method to disable telemetry at this point.
+  # Configuring the driver here is too late as the manager is already set at
+  # the system level.
+  #
+  # To test that telemetry is not being send, use the command:
+  # `DEBUG=true SE_CLEAR_CACHE=true rspec`
+  #
+  # Ref: SeleniumHQ/selenium#13173
+  ENV['SE_AVOID_STATS'] = 'true'
+
   opts = Selenium::WebDriver::Chrome::Options.new
 
   # See https://github.com/GoogleChrome/chrome-launcher/blob/main/docs/chrome-flags-for-tools.md


### PR DESCRIPTION
Ref: SeleniumHQ/selenium#13173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Chrome driver configuration to enhance testing performance by opting out of Selenium's data collection. Added comments for clarity on the new environment variable setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->