### PR TITLE
Add i18n-tasks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,6 +41,35 @@ jobs:
       if: steps.changed-files.outputs.any_changed == 'true'
       run: bundle exec rubocop --format github
 
+  i18n:
+    name: I18n tasks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    concurrency:
+      group: "${{ github.workflow }} / i18n @ ${{ github.ref }}"
+      cancel-in-progress: true
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: tj-actions/changed-files@v45
+      id: changed-files
+      with:
+        files: |
+          .github/workflows/lint.yml
+          config/i18n-tasks.yml
+          config/locales/**/*.yml
+          app/**/*
+          Gemfile*
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3.6'
+        bundler-cache: true
+    - name: Run i18n-tasks health
+      if: steps.changed-files.outputs.any_changed == 'true'
+      run: bundle exec i18n-tasks health
+
   slimlint:
     name: Slim-Lint
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'i18n-tasks', require: false
   gem 'rack-mini-profiler'
   gem 'web-console'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,9 +122,21 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashdiff (1.1.2)
+    highline (3.1.1)
+      reline
     htmlentities (4.3.4)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.14)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 3.2.2.1)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     io-console (0.8.0)
     irb (1.14.1)
       rdoc (>= 4.0.0)
@@ -220,6 +232,9 @@ GEM
     rails-html-sanitizer (1.6.1)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.2)
       actionpack (= 7.2.2)
       activesupport (= 7.2.2)
@@ -320,6 +335,7 @@ GEM
       slim (>= 3.0, < 6.0)
     stringio (3.1.2)
     temple (0.10.3)
+    terminal-table (1.6.0)
     thor (1.3.2)
     tilt (2.4.0)
     timeout (0.4.2)
@@ -361,6 +377,7 @@ DEPENDENCIES
   email_spec
   factory_bot_rails
   faker
+  i18n-tasks
   newrelic_rpm (~> 9.16)
   pg (~> 1.5)
   pry

--- a/README.md
+++ b/README.md
@@ -17,30 +17,32 @@ This is an opinionated starter web application based on the following technology
 * [RSpec][:rspec-url]
 * [Bootstrap 5.3.3][:bootstrap-url]
 * [Autoprefixer][:autoprefixer-url]
-* [Font Awesome 6.6.0 SVG][:fontawesome-url]
+* [Font Awesome 6.7.1 SVG][:fontawesome-url]
 * [Slim][:slim-url]
 * [RuboCop][:rubocop-url]
 * [RuboCop RSpec][:rubocop-rspec-url]
 * [Slim-Lint][:slim-lint-url]
 * [stylelint][:stylelint-url]
+* [i18n-tasks][:i18n-tasks-url]
 
 [:autoprefixer-url]: https://github.com/postcss/autoprefixer
-[:bootstrap-url]: https://getbootstrap.com/
-[:fontawesome-url]: https://fontawesome.com/
+[:bootstrap-url]: https://getbootstrap.com
+[:fontawesome-url]: https://fontawesome.com
+[:i18n-tasks-url]: https://github.com/glebm/i18n-tasks
 [:pnpm-url]: https://pnpm.io/
-[:postgresql-url]: https://www.postgresql.org/
-[:puma-url]: https://puma.io/
-[:redis-url]: https://redis.io/
-[:rspec-url]: https://rspec.info/
+[:postgresql-url]: https://www.postgresql.org
+[:puma-url]: https://puma.io
+[:redis-url]: https://redis.io
+[:rspec-url]: https://rspec.info
 [:rubocop-rspec-url]: https://github.com/backus/rubocop-rspec
 [:rubocop-url]: https://github.com/bbatsov/rubocop
-[:ruby-on-rails-url]: https://rubyonrails.org/
+[:ruby-on-rails-url]: https://rubyonrails.org
 [:ruby-url]: https://www.ruby-lang.org/en/
 [:shakapacker-url]: https://github.com/shakacode/shakapacker
 [:slim-lint-url]: https://github.com/sds/slim-lint
-[:slim-url]: http://slim-lang.com/
-[:stylelint-url]: https://stylelint.io/
-[:webpack-url]: https://webpack.js.org/
+[:slim-url]: https://slim-lang.com
+[:stylelint-url]: https://stylelint.io
+[:webpack-url]: https://webpack.js.org
 
 Starter App is deployable on [Heroku](https://www.heroku.com/). Demo: https://ruby3-rails7-bootstrap-heroku.herokuapp.com/
 

--- a/app/views/pages/home.html.slim
+++ b/app/views/pages/home.html.slim
@@ -16,4 +16,4 @@ ul.list-inline.lead
     small.text-body-secondary< 5.3.3
   li.list-inline-item
     | Font Awesome (SVG)
-    small.text-body-secondary< 6.6.0
+    small.text-body-secondary< 6.7.1

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,178 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+base_locale: en
+## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
+# locales: [es, fr]
+## Reporting locale, default: en. Available: en, ru.
+# internal_locale: en
+
+# Read and write translations.
+data:
+  ## Translations are read from the file system. Supported format: YAML, JSON.
+  ## Provide a custom adapter:
+  # adapter: I18n::Tasks::Data::FileSystem
+
+  # Locale files or `Dir.glob` patterns where translations are read from:
+  read:
+    ## Default:
+    # - config/locales/%{locale}.yml
+    ## More files:
+    # - config/locales/**/*.%{locale}.yml
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+    ## For example, write devise and simple form keys to their respective files:
+    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
+    ## Catch-all default:
+    # - config/locales/%{locale}.yml
+
+  # External locale data (e.g. gems).
+  # This data is not considered unused and is never written to.
+  external:
+    ## Example (replace %#= with %=):
+    # - "<%#= %x[bundle info vagrant --path].chomp %>/templates/locales/%{locale}.yml"
+
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
+  # router: conservative_router
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+  ## Pretty-print JSON:
+  # json:
+  #   write:
+  #     indent: '  '
+  #     space: ' '
+  #     object_nl: "\n"
+  #     array_nl: "\n"
+
+# Find translate calls
+search:
+  ## Paths or `Find.find` patterns to search in:
+  # paths:
+  #  - app/
+
+  ## Root directories for relative keys resolution.
+  # relative_roots:
+  #   - app/controllers
+  #   - app/helpers
+  #   - app/mailers
+  #   - app/presenters
+  #   - app/views
+
+  ## Directories where method names which should not be part of a relative key resolution.
+  # By default, if a relative translation is used inside a method, the name of the method will be considered part of the resolved key.
+  # Directories listed here will not consider the name of the method part of the resolved key
+  #
+  # relative_exclude_method_name_paths:
+  #  -
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  ##   *.jpg *.jpeg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less
+  ##   *.yml *.json *.zip *.tar.gz *.swf *.flv *.mp3 *.wav *.flac *.webm *.mp4 *.ogg *.opus *.webp *.map *.xlsx
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+    - app/assets/videos
+    - app/assets/builds
+
+  ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
+  ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
+  # only: ["*.rb", "*.html.slim"]
+
+  ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
+  # strict: true
+
+  ## Allows adding ast_matchers for finding translations using the AST-scanners
+  ## The available matchers are:
+  ## - RailsModelMatcher
+  ##     Matches ActiveRecord translations like
+  ##     User.human_attribute_name(:email) and User.model_name.human
+  ## - DefaultI18nSubjectMatcher
+  ##     Matches ActionMailer's default_i18n_subject method
+  ##
+  ## To implement your own, please see `I18n::Tasks::Scanners::AstMatchers::BaseMatcher`.
+  # ast_matchers:
+  #   - 'I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher'
+  #   - 'I18n::Tasks::Scanners::AstMatchers::DefaultI18nSubjectMatcher'
+
+  ## Multiple scanners can be used. Their results are merged.
+  ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
+  ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example
+
+## Translation Services
+# translation:
+#   # Google Translate
+#   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
+#   google_translate_api_key: "AbC-dEf5"
+#   # DeepL Pro Translate
+#   # Get an API key and subscription at https://www.deepl.com/pro to use DeepL Pro
+#   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"
+#   # deepl_host: "https://api.deepl.com"
+#   # deepl_version: "v2"
+#   # deepl_glossary_ids:
+#   #   - f28106eb-0e06-489e-82c6-8215d6f95089
+#   #   - 2c6415be-1852-4f54-9e1b-d800463496b4
+#   # add additional options to the DeepL.translate call: https://www.deepl.com/docs-api/translate-text/translate-text/
+#   deepl_options:
+#     formality: prefer_less
+#   # OpenAI
+#   openai_api_key: "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+#   # openai_model: "gpt-3.5-turbo" # see https://platform.openai.com/docs/models
+#   # may contain `%{from}` and `%{to}`, which will be replaced by source and target locale codes, respectively (using `Kernel.format`)
+#   # openai_system_prompt: >-
+#   #   You are a professional translator that translates content from the %{from} locale
+#   #   to the %{to} locale in an i18n locale array.
+#   #
+#   #   The array has a structured format and contains multiple strings. Your task is to translate
+#   #   each of these strings and create a new array with the translated strings.
+#   #
+#   #   HTML markups (enclosed in < and > characters) must not be changed under any circumstance.
+#   #   Variables (starting with %%{ and ending with }) must not be changed under any circumstance.
+#   #
+#   #   Keep in mind the context of all the strings for a more accurate translation.
+
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+
+## Consider these keys used:
+# ignore_unused:
+# - 'activerecord.attributes.*'
+# - '{devise,kaminari,will_paginate}.*'
+# - 'simple_form.{yes,no}'
+# - 'simple_form.{placeholders,hints,labels}.*'
+# - 'simple_form.{error_notification,required}.:'
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Exclude these keys from the `i18n-tasks check-consistent-interpolations` report:
+# ignore_inconsistent_interpolations:
+# - 'activerecord.attributes.*'
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*
+
+## Sometimes, it isn't possible for i18n-tasks to match the key correctly,
+## e.g. in case of a relative key defined in a helper method.
+## In these cases you can use the built-in PatternMapper to map patterns to keys, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       only: %w(*.html.haml *.html.slim),
+#       patterns: [['= title\b', '.page_title']] %>
+#
+# The PatternMapper can also match key literals via a special %{key} interpolation, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,37 +1,7 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
+---
 en:
-  app_name: "Rails 7 Starter App"
-  meta_description: "An opinionated starter application based on Ruby 3.1, Rails 7.1, Webpack 5, Yarn, and Bootstrap 5"
+  app_name: Rails 7 Starter App
+  meta_description: An opinionated starter application based on Ruby 3.3, Rails 7.2, Webpack 5, Yarn, and Bootstrap 5
   shared:
     navbar:
-      toggle_navigation: "Toggle Navigation"
+      toggle_navigation: Toggle Navigation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new job for internationalization tasks in the GitHub Actions workflow.
	- Added a new configuration file for managing internationalization tasks.
	- Updated the technology stack in the README to include `i18n-tasks`.

- **Bug Fixes**
	- Updated version of Font Awesome in multiple files to ensure consistency.

- **Documentation**
	- Updated URLs in the README for various technologies to remove trailing slashes.

- **Chores**
	- Added the `i18n-tasks` gem to the development group in the Gemfile.
	- Modified locale file structure for better clarity and updated values for application metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->