### PR TITLE
Add Dependabot minimum package age

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,18 @@ updates:
     schedule:
       interval: daily
       time: "04:00"
+    cooldown:
+      default-days: 5
   - package-ecosystem: bundler
     directory: "/"
     schedule:
       interval: daily
       time: "04:00"
+    cooldown:
+      default-days: 5
+      semver-patch-days: 5
+      semver-minor-days: 10
+      semver-major-days: 15
     groups:
       rubocop:
         patterns:
@@ -33,6 +40,11 @@ updates:
     schedule:
       interval: daily
       time: "04:00"
+    cooldown:
+      default-days: 5
+      semver-patch-days: 5
+      semver-minor-days: 10
+      semver-major-days: 15
     groups:
       babel:
         patterns:


### PR DESCRIPTION
Delay Dependabot updates so new releases are not proposed immediately after publication, reducing exposure to supply chain attacks during the first few days after release.

Use semver-specific cooldowns for Bundler and npm updates, with a five-day fallback for GitHub Actions where per-update values are not available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation settings to add cooldown periods between updates. Introduces semver-aware delays (separate waits for patch, minor, and major updates) for affected ecosystems, spacing Dependabot PRs to reduce rapid successive updates and smooth update cadence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->